### PR TITLE
Dev

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -19,12 +19,6 @@ class Imputer(Protocol):
     def transform(self, X: np.ndarray) -> np.ndarray: ...
     def fit_transform(self, X: np.ndarray) -> np.ndarray: ...
 
-
-# class MySimpleImputer(SimpleImputer):
-#     def fit(X):
-#         # filter any features with fewer than 2
-
-
 class NullImputer:
     # a null imputer that does nothing
     def fit(self, X: np.ndarray) -> None:
@@ -44,6 +38,7 @@ class HandleMissingValuesOptions(StrEnum):
 
 
 class Options(BaseModel):
+    # pydantic validator object for options.json
     treat_zeros_as_missing: bool = Field(
         default=False, description="If true, zeros are treated as missing values (NaN)."
     )
@@ -63,6 +58,7 @@ def set_zeros_to_nan(ar: np.ndarray) -> np.ndarray:
 
 
 def no_filter(ar: np.ndarray) -> np.ndarray:
+    # a null filter that does nothing
     return ar
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -1,0 +1,183 @@
+import re
+import pandas as pd
+import json
+from typing import Callable, Protocol, List, Tuple
+import sys
+from enum import StrEnum
+from pydantic import BaseModel, Field
+from sklearn.impute import SimpleImputer
+import numpy as np
+from pathlib import Path
+from sklearn.decomposition import PCA
+
+Filter = Callable[[np.ndarray], np.ndarray]
+
+
+class Imputer(Protocol):
+    # define interface for imputers - mirror sklearn's various imputers
+    def fit(self, X: np.ndarray) -> None: ...
+    def transform(self, X: np.ndarray) -> np.ndarray: ...
+    def fit_transform(self, X: np.ndarray) -> np.ndarray: ...
+
+
+class NullImputer:
+    # a null imputer that does nothing
+    def fit(self, X: np.ndarray) -> None:
+        pass
+
+    def transform(self, X: np.ndarray) -> np.ndarray:
+        return X
+
+    def fit_transform(self, X: np.ndarray) -> np.ndarray:
+        return X
+
+
+class HandleMissingValuesOptions(StrEnum):
+    GENEWISE_DELETION = "gene wise deletion"
+    IMPUTE_GENE_MEAN_EXPRESSION = "impute gene mean expression"
+    IMPUTE_GENE_MEDIAN_EXPRESSION = "impute gene median expression"
+
+
+class Options(BaseModel):
+    treat_zeros_as_missing: bool = Field(
+        default=False, description="If true, zeros are treated as missing values (NaN)."
+    )
+    handle_missing_values: HandleMissingValuesOptions = Field(
+        default=HandleMissingValuesOptions.GENEWISE_DELETION,
+        description="Method to handle missing genes.",
+    )
+    scale_features: bool = Field(
+        default=True,
+        description="If true, data is scaled to have mean 0 and variance 1.",
+    )
+
+
+def set_zeros_to_nan(ar: np.ndarray) -> np.ndarray:
+    ar[ar == 0] = np.nan
+    return ar
+
+
+def no_filter(ar: np.ndarray) -> np.ndarray:
+    return ar
+
+
+def scale_cols(ar: np.ndarray) -> np.ndarray:
+    # Scale each column to have mean 0 and variance 1
+    means = np.mean(ar, axis=0)
+    stds = np.std(ar, axis=0)
+    return (ar - means) / stds
+
+
+def gene_wise_deletion(ar: np.ndarray) -> np.ndarray:
+    # Remove cols with any NaN values
+    return ar[:, ~np.isnan(ar).any(axis=0)]
+
+
+def get_treat_zeros_filter(opts: Options) -> Filter:
+    if opts.treat_zeros_as_missing:
+        return set_zeros_to_nan
+    return no_filter
+
+
+def get_missing_values_filter(opts: Options) -> Filter:
+    if opts.handle_missing_values == HandleMissingValuesOptions.GENEWISE_DELETION:
+        return gene_wise_deletion
+    return no_filter
+
+
+def get_imputer(opts: Options) -> Imputer:
+    if (
+        opts.handle_missing_values
+        == HandleMissingValuesOptions.IMPUTE_GENE_MEAN_EXPRESSION
+    ):
+        return SimpleImputer(strategy="mean")
+    elif (
+        opts.handle_missing_values
+        == HandleMissingValuesOptions.IMPUTE_GENE_MEDIAN_EXPRESSION
+    ):
+        return SimpleImputer(strategy="median")
+    else:
+        return NullImputer()
+
+
+def get_scale_filter(opts: Options) -> Filter:
+    if opts.scale_features:
+        return scale_cols
+    return no_filter
+
+
+def read_input_file(file_path):
+    df = pd.read_csv(file_path, delimiter="\t", index_col=0, usecols=["tpm", "gene_id"])
+    return df
+
+
+def read_all_input_files(root_path: Path) -> Tuple[np.ndarray, List[str]]:
+    data_frames = []
+    donor_names = []
+    pattern = re.compile(r"^(Donor\d+)-.*\.tsv$")
+    for file_path in root_path.glob("*.tsv"):
+        match = pattern.match(file_path.name)
+        if not match:
+            Warning(
+                f"File {file_path.name} does not match expected pattern and will be skipped."
+            )
+            continue
+        df = read_input_file(file_path)
+        data_frames.append(df)
+        donor_names.append(match.group(1))
+    # merge all the data frames so that the index is the union of all gene_ids
+    merged_df = pd.concat(data_frames, axis=1, join="outer")
+    # convert to numpy array and transpose so that rows are samples and columns are genes
+    return merged_df.to_numpy().T, donor_names
+
+
+def read_options(file_path: Path) -> Options:
+    with open(file_path, "r") as f:
+        config = json.load(f)
+    return Options(**config)
+
+
+def prepare_data(ar: np.ndarray, opts: Options) -> np.ndarray:
+    treat_zeros_filter = get_treat_zeros_filter(opts)
+    missing_values_filter = get_missing_values_filter(opts)
+    scale_filter = get_scale_filter(opts)
+    imputer = get_imputer(opts)
+
+    # Apply filters and imputer
+    ar = treat_zeros_filter(ar)
+    ar = missing_values_filter(ar)
+    # log transform before imputing
+    ar = np.log1p(ar)
+    # impute missing values if requested
+    ar = imputer.fit_transform(ar)
+    print("After imputation:", ar)
+    # if any missing values remain this indicates a bug
+    assert not np.isnan(ar).any(), "Missing values at this stage indicates a bug"
+    # scale features if requested
+    ar = scale_filter(ar)
+    return ar
+
+
+def do_pca(ar: np.ndarray) -> np.ndarray:
+    pca = PCA()
+    transformed = pca.fit_transform(ar)
+    return transformed
+
+
+def main(root_path):
+    x, donor_names = read_all_input_files(Path(root_path))
+    opts = read_options(Path(root_path) / "options.json")
+    x_prepared = prepare_data(x, opts)
+    x_pca = do_pca(x_prepared)
+    # get the components into a dataframe
+    df_pca = pd.DataFrame(
+        x_pca, index=donor_names, columns=[f"PC{i+1}" for i in range(x_pca.shape[1])]
+    )
+    df_pca.index.name = "Sample"
+    # save to tsv
+    df_pca.to_csv(Path(root_path) / "results.tsv", sep="\t")
+
+
+if __name__ == "__main__":
+    root_path = sys.argv[1]
+    main(root_path)

--- a/src/app.py
+++ b/src/app.py
@@ -20,6 +20,11 @@ class Imputer(Protocol):
     def fit_transform(self, X: np.ndarray) -> np.ndarray: ...
 
 
+# class MySimpleImputer(SimpleImputer):
+#     def fit(X):
+#         # filter any features with fewer than 2
+
+
 class NullImputer:
     # a null imputer that does nothing
     def fit(self, X: np.ndarray) -> None:
@@ -65,6 +70,12 @@ def scale_cols(ar: np.ndarray) -> np.ndarray:
     # Scale each column to have mean 0 and variance 1
     means = np.mean(ar, axis=0)
     stds = np.std(ar, axis=0)
+    # check if standard deviation is nonzero
+    if any(stds == 0.0):
+        raise ValueError(
+            "Data could not be scaled due to zero variances being found. "
+            "This indicates that all expression values of at least one gene are equal"
+        )
     return (ar - means) / stds
 
 
@@ -125,6 +136,9 @@ def read_all_input_files(root_path: Path) -> Tuple[np.ndarray, List[str]]:
         df = read_input_file(file_path)
         data_frames.append(df)
         donor_names.append(match.group(1))
+
+    if len(data_frames) == 0:
+        raise ValueError(f"No files found matching {pattern}")
     # merge all the data frames so that the index is the union of all gene_ids
     merged_df = pd.concat(data_frames, axis=1, join="outer")
     # convert to numpy array and transpose so that rows are samples and columns are genes
@@ -150,7 +164,7 @@ def prepare_data(ar: np.ndarray, opts: Options) -> np.ndarray:
     ar = np.log1p(ar)
     # impute missing values if requested
     ar = imputer.fit_transform(ar)
-    print("After imputation:", ar)
+
     # if any missing values remain this indicates a bug
     assert not np.isnan(ar).any(), "Missing values at this stage indicates a bug"
     # scale features if requested

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,0 +1,4 @@
+pydantic>=2.11.10
+scikit-learn>=1.7.2
+pandas>=2.2.3
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import sys
+from pathlib import Path
+
+
+# Add src directory to Python path so imports work
+src_path = (
+    Path(__file__).parent.parent / "src"
+)  # Go up one level from tests/ to project root, then to src/
+sys.path.insert(0, str(src_path))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -90,59 +90,6 @@ class TestFilterFunctions:
         np.testing.assert_array_equal(result, expected)
 
 
-class TestGetterFunctions:
-    def test_get_treat_zeros_filter(self):
-        opts_true = Options(treat_zeros_as_missing=True)
-        opts_false = Options(treat_zeros_as_missing=False)
-
-        filter_true = get_treat_zeros_filter(opts_true)
-        filter_false = get_treat_zeros_filter(opts_false)
-
-        data = np.array([[0, 1]], dtype=float)
-        result_true = filter_true(data.copy())
-        result_false = filter_false(data.copy())
-
-        assert np.isnan(result_true[0, 0])
-        assert result_false[0, 0] == 0
-
-    def test_get_missing_values_filter(self):
-        opts_deletion = Options(
-            handle_missing_values=HandleMissingValuesOptions.GENEWISE_DELETION
-        )
-        opts_no_deletion = Options(
-            handle_missing_values=HandleMissingValuesOptions.IMPUTE_GENE_MEAN_EXPRESSION
-        )
-
-        filter_deletion = get_missing_values_filter(opts_deletion)
-        filter_no_deletion = get_missing_values_filter(opts_no_deletion)
-
-        data = np.array([[1, np.nan], [2, 3]])
-        result_deletion = filter_deletion(data)
-        result_no_deletion = filter_no_deletion(data)
-
-        assert result_deletion.shape[1] == 1  # Column with NaN removed
-        assert result_no_deletion.shape[1] == 2  # No columns removed
-
-    def test_get_imputer(self):
-        opts_mean = Options(
-            handle_missing_values=HandleMissingValuesOptions.IMPUTE_GENE_MEAN_EXPRESSION
-        )
-        opts_median = Options(
-            handle_missing_values=HandleMissingValuesOptions.IMPUTE_GENE_MEDIAN_EXPRESSION
-        )
-        opts_none = Options(
-            handle_missing_values=HandleMissingValuesOptions.GENEWISE_DELETION
-        )
-
-        imputer_mean = get_imputer(opts_mean)
-        imputer_median = get_imputer(opts_median)
-        imputer_none = get_imputer(opts_none)
-
-        assert hasattr(imputer_mean, "strategy")
-        assert hasattr(imputer_median, "strategy")
-        assert isinstance(imputer_none, NullImputer)
-
-
 class TestFileOperations:
     def create_test_tsv(self, path: Path, data: dict):
         """Helper to create test TSV files"""

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -187,6 +187,28 @@ class TestFileOperations:
             assert "Donor1" in donor_names
             assert "Donor2" in donor_names
             mock_warning.assert_called_once()
+    def test_read_input_non_matching_index(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+
+
+            # Create test data with non-matching index
+            data = {"tpm": [1.5, 2.0, 3.5]}
+            df = pd.DataFrame(data)
+            df.index = ["geneA", "geneB", "geneC"]  # Non-numeric index
+            df.index.name = "gene_id"
+            df.to_csv(temp_path / "Donor1-sample.tsv", sep="\t")
+
+            data2 = {"tpm": [4.5, 5.0, 6.5]}
+            df2 = pd.DataFrame(data2)
+            df2.index = ["geneB", "geneC", "geneD"]  # Non-matching index
+            df2.index.name = "gene_id"
+            df2.to_csv(temp_path / "Donor2-sample.tsv", sep="\t")
+            result_data, donor_names = read_all_input_files(temp_path)
+            expected = np.array([[1.5, np.nan], [2.0, 4.5], [3.5, 5.0], [np.nan, 6.5]]).T
+            np.testing.assert_array_equal(result_data, expected) # assert equal (allowing nans to match)
+            assert donor_names == ["Donor1", "Donor2"]
+        
 
     def test_read_all_files_no_files(self):
         """Edge case where no files are found"""

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -188,6 +188,14 @@ class TestFileOperations:
             assert "Donor2" in donor_names
             mock_warning.assert_called_once()
 
+    def test_read_all_files_no_files(self):
+        """Edge case where no files are found"""
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            with pytest.raises(ValueError, match="No files found matching"):
+                result_data, donor_names = read_all_input_files(temp_path)
+
     def test_read_options(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
@@ -238,6 +246,30 @@ class TestDataProcessing:
         # Should have same shape (no gene deletion) and no NaNs
         assert result.shape[1] == data.shape[1]
         assert not np.isnan(result).any()
+
+    @pytest.mark.parametrize(
+        "data",
+        [np.array([[1.0, 2.0, 3.0], [4.0, np.nan, 6.0]]), np.array([[1.0, 2.0, 3.0]])],
+    )
+    @pytest.mark.parametrize(
+        "handle_missing_values",
+        [
+            option.value
+            for option in HandleMissingValuesOptions
+            if option != HandleMissingValuesOptions.GENEWISE_DELETION
+        ],
+    )
+    @pytest.mark.parametrize("scale_features", [True])
+    def test_prepare_data_with_very_few_unique_data_points_with_scaling(
+        self, data, handle_missing_values, scale_features
+    ):
+        opts = Options(
+            handle_missing_values=handle_missing_values,
+            scale_features=scale_features,
+        )
+
+        with pytest.raises(ValueError, match="Data could not be scaled"):
+            result = prepare_data(data, opts)
 
     def test_do_pca(self):
         # Create test data

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,314 @@
+import pytest
+import numpy as np
+import pandas as pd
+from pathlib import Path
+import tempfile
+import json
+from unittest.mock import patch, MagicMock
+
+from app import (
+    Options,
+    HandleMissingValuesOptions,
+    NullImputer,
+    set_zeros_to_nan,
+    no_filter,
+    scale_cols,
+    gene_wise_deletion,
+    get_treat_zeros_filter,
+    get_missing_values_filter,
+    get_imputer,
+    read_input_file,
+    read_all_input_files,
+    read_options,
+    prepare_data,
+    do_pca,
+    main,
+)
+
+
+class TestNullImputer:
+    def test_null_imputer_does_nothing(self):
+        imputer = NullImputer()
+        data = np.array([[1, 2], [3, 4]], dtype=float)
+
+        imputer.fit(data)
+        result = imputer.transform(data)
+        assert np.array_equal(result, data)
+
+        result = imputer.fit_transform(data)
+        assert np.array_equal(result, data)
+
+
+class TestOptions:
+    def test_default_options(self):
+        opts = Options()
+        assert opts.treat_zeros_as_missing == False
+        assert (
+            opts.handle_missing_values == HandleMissingValuesOptions.GENEWISE_DELETION
+        )
+        assert opts.scale_features == True
+
+    def test_options_from_dict(self):
+        data = {
+            "treat_zeros_as_missing": True,
+            "handle_missing_values": "impute gene mean expression",
+            "scale_features": False,
+        }
+        opts = Options(**data)
+        assert opts.treat_zeros_as_missing == True
+        assert (
+            opts.handle_missing_values
+            == HandleMissingValuesOptions.IMPUTE_GENE_MEAN_EXPRESSION
+        )
+        assert opts.scale_features == False
+
+
+class TestFilterFunctions:
+    def test_set_zeros_to_nan(self):
+        data = np.array([[0, 1, 2], [3, 0, 5]], dtype=float)
+        result = set_zeros_to_nan(data.copy())
+        expected = np.array([[np.nan, 1, 2], [3, np.nan, 5]], dtype=float)
+        np.testing.assert_array_equal(result, expected)
+
+    def test_no_filter(self):
+        data = np.array([[1, 2], [3, 4]], dtype=float)
+        result = no_filter(data)
+        assert np.array_equal(result, data)
+
+    def test_scale_cols(self):
+        data = np.array([[1, 2], [3, 4]], dtype=float)
+        result = scale_cols(data)
+
+        # Check that each column has mean ~0 and std ~1
+        assert np.allclose(np.mean(result, axis=0), 0, atol=1e-10)
+        assert np.allclose(np.std(result, axis=0), 1, atol=1e-10)
+
+    def test_gene_wise_deletion(self):
+        data = np.array([[1, np.nan, 3], [4, 5, 6]])
+        result = gene_wise_deletion(data)
+        expected = np.array([[1, 3], [4, 6]])
+        np.testing.assert_array_equal(result, expected)
+
+
+class TestGetterFunctions:
+    def test_get_treat_zeros_filter(self):
+        opts_true = Options(treat_zeros_as_missing=True)
+        opts_false = Options(treat_zeros_as_missing=False)
+
+        filter_true = get_treat_zeros_filter(opts_true)
+        filter_false = get_treat_zeros_filter(opts_false)
+
+        data = np.array([[0, 1]], dtype=float)
+        result_true = filter_true(data.copy())
+        result_false = filter_false(data.copy())
+
+        assert np.isnan(result_true[0, 0])
+        assert result_false[0, 0] == 0
+
+    def test_get_missing_values_filter(self):
+        opts_deletion = Options(
+            handle_missing_values=HandleMissingValuesOptions.GENEWISE_DELETION
+        )
+        opts_no_deletion = Options(
+            handle_missing_values=HandleMissingValuesOptions.IMPUTE_GENE_MEAN_EXPRESSION
+        )
+
+        filter_deletion = get_missing_values_filter(opts_deletion)
+        filter_no_deletion = get_missing_values_filter(opts_no_deletion)
+
+        data = np.array([[1, np.nan], [2, 3]])
+        result_deletion = filter_deletion(data)
+        result_no_deletion = filter_no_deletion(data)
+
+        assert result_deletion.shape[1] == 1  # Column with NaN removed
+        assert result_no_deletion.shape[1] == 2  # No columns removed
+
+    def test_get_imputer(self):
+        opts_mean = Options(
+            handle_missing_values=HandleMissingValuesOptions.IMPUTE_GENE_MEAN_EXPRESSION
+        )
+        opts_median = Options(
+            handle_missing_values=HandleMissingValuesOptions.IMPUTE_GENE_MEDIAN_EXPRESSION
+        )
+        opts_none = Options(
+            handle_missing_values=HandleMissingValuesOptions.GENEWISE_DELETION
+        )
+
+        imputer_mean = get_imputer(opts_mean)
+        imputer_median = get_imputer(opts_median)
+        imputer_none = get_imputer(opts_none)
+
+        assert hasattr(imputer_mean, "strategy")
+        assert hasattr(imputer_median, "strategy")
+        assert isinstance(imputer_none, NullImputer)
+
+
+class TestFileOperations:
+    def create_test_tsv(self, path: Path, data: dict):
+        """Helper to create test TSV files"""
+        df = pd.DataFrame(data)
+        df.index.name = "gene_id"
+        df.to_csv(path, sep="\t")
+
+    def test_read_input_file(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            test_file = temp_path / "test.tsv"
+
+            # Create test data
+            data = {"tpm": [1.5, 2.0, 3.5], "other_col": [10, 20, 30]}
+            self.create_test_tsv(test_file, data)
+
+            result = read_input_file(test_file)
+            assert isinstance(result, pd.DataFrame)
+            assert "tpm" in result.columns
+            assert len(result) == 3
+
+    def test_read_all_input_files(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+
+            # Create test files with proper naming
+            files = [
+                ("Donor1-sample.tsv", {"tpm": [1, 2, 3]}),
+                ("Donor2-sample.tsv", {"tpm": [4, 5, 6]}),
+                ("invalid-file.tsv", {"tpm": [7, 8, 9]}),  # Should be skipped
+            ]
+
+            for filename, data in files:
+                self.create_test_tsv(temp_path / filename, data)
+
+            with patch("app.Warning") as mock_warning:
+                result_data, donor_names = read_all_input_files(temp_path)
+
+            assert result_data.shape[0] == 2  # 2 valid files
+            assert result_data.shape[1] == 3  # 3 genes
+            assert len(donor_names) == 2
+            assert "Donor1" in donor_names
+            assert "Donor2" in donor_names
+            mock_warning.assert_called_once()
+
+    def test_read_options(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            options_file = temp_path / "options.json"
+
+            options_data = {
+                "treat_zeros_as_missing": True,
+                "handle_missing_values": "impute gene mean expression",
+                "scale_features": False,
+            }
+
+            with open(options_file, "w") as f:
+                json.dump(options_data, f)
+
+            result = read_options(options_file)
+            assert isinstance(result, Options)
+            assert result.treat_zeros_as_missing == True
+            assert (
+                result.handle_missing_values
+                == HandleMissingValuesOptions.IMPUTE_GENE_MEAN_EXPRESSION
+            )
+            assert result.scale_features == False
+
+
+class TestDataProcessing:
+    def test_prepare_data_with_defaults(self):
+        # Create test data with some zeros and NaNs
+        data = np.array([[1.0, 2.0, 0.0], [0.0, 3.0, 4.0], [5.0, np.nan, 6.0]])
+
+        opts = Options(
+            handle_missing_values=HandleMissingValuesOptions.GENEWISE_DELETION
+        )
+        result = prepare_data(data, opts)
+
+        # Should have removed columns with NaN/0 after zero treatment
+        assert result.shape[1] < data.shape[1]
+        assert not np.isnan(result).any()
+
+    def test_prepare_data_with_imputation(self):
+        data = np.array([[1.0, 2.0, 3.0], [4.0, np.nan, 6.0], [7.0, 8.0, 9.0]])
+
+        opts = Options(
+            handle_missing_values=HandleMissingValuesOptions.IMPUTE_GENE_MEAN_EXPRESSION,
+            scale_features=False,
+        )
+        result = prepare_data(data, opts)
+
+        # Should have same shape (no gene deletion) and no NaNs
+        assert result.shape[1] == data.shape[1]
+        assert not np.isnan(result).any()
+
+    def test_do_pca(self):
+        # Create test data
+        data = np.random.rand(10, 5)  # 10 samples, 5 features
+        result = do_pca(data)
+
+        assert result.shape[0] == data.shape[0]  # Same number of samples
+        assert result.shape[1] <= data.shape[1]  # PCs <= features
+
+
+# Fixtures for common test data
+@pytest.fixture
+def sample_data():
+    return np.array(
+        [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 0.0], [9.0, 10.0, 11.0, 12.0]]
+    )
+
+
+# test end to end with different combinations of options
+class TestEndToEnd:
+    @pytest.mark.parametrize("treat_zeros", [True, False])
+    @pytest.mark.parametrize(
+        "missing_value_strategy",
+        [
+            HandleMissingValuesOptions.GENEWISE_DELETION,
+            HandleMissingValuesOptions.IMPUTE_GENE_MEAN_EXPRESSION,
+            HandleMissingValuesOptions.IMPUTE_GENE_MEDIAN_EXPRESSION,
+        ],
+    )
+    @pytest.mark.parametrize("scale_features", [True, False])
+    def test_end_to_end(
+        self, sample_data, treat_zeros, missing_value_strategy, scale_features
+    ):
+
+        # write sample data to three files beginning Donor1-sample.tsv, Donor2-sample.tsv, Donor3-sample.tsv
+        with tempfile.TemporaryDirectory() as root_dir:
+            root_dir = Path(root_dir)
+            for i in range(0, 3):
+                print(sample_data[i, np.newaxis].shape)
+                file_path = root_dir / f"Donor{i}-sample.tsv"
+                df = pd.DataFrame(
+                    sample_data[i, np.newaxis].T,
+                    index=["geneA", "geneB", "geneC", "geneD"],
+                    columns=["tpm"],
+                )
+                df.index.name = "gene_id"
+                df.to_csv(file_path, sep="\t", index=True)
+            # Create options file
+            options = {
+                "treat_zeros_as_missing": treat_zeros,
+                "handle_missing_values": missing_value_strategy.value,
+                "scale_features": scale_features,
+            }
+            options_path = root_dir / "options.json"
+            with open(options_path, "w") as f:
+                json.dump(options, f)
+            # Run main
+            main(root_dir)
+
+            # check the output files exist
+            pca_output = root_dir / "results.tsv"
+            # load the file and check it has the right shape
+            assert pca_output.exists()
+            df = pd.read_csv(pca_output, sep="\t", index_col=0)
+            assert df.shape[0] == 3  # 3 donors
+            # number of PCs should be 1 < the number of genes plus the  (4)
+            assert df.shape[1] == 3
+
+            # assert the column names are PC1, PC2, PC3
+            assert list(df.columns) == ["PC1", "PC2", "PC3"]
+
+            # assert the Index is named Sample
+            assert df.index.name == "Sample"
+            assert list(df.index) == ["Donor1", "Donor2", "Donor0"]


### PR DESCRIPTION
Implements pca analysis with various pre-processing options
1. treat zeros as missing (these will be changed to NaN and then excluded or imputed depending on the other options)
2. handle missing values by either genewise (column/feature) deletion or (genewise) mean or median imputation
3. scale or not the columns of the input data to have equal variance.

You should get a good idea of the options and their expected values by looking at the `Options` `HandleMissingValuesOptions` classes

It would be very easy to support other imputation strategies (anything that could be defined using sklearn's impute package would be very easy.